### PR TITLE
Bug fix in getValues, getElementData now returns compID, setLoadFactor function added

### DIFF
--- a/src/TACSAssembler.cpp
+++ b/src/TACSAssembler.cpp
@@ -41,7 +41,7 @@
   tacs_comm:           the TACS communicator
   varsPerNode:         the number of degrees of freedom per node
   numOwnedNodes:       the number of locally-owned nodes
-  numElements:         the number of elements in the mesh
+  numElements:         the number of locally-owned elements in the mesh
   numDependentNodes:   the number of dependent nodes in the mesh
 */
 TACSAssembler::TACSAssembler( MPI_Comm _tacs_comm,

--- a/tacs/TACS.pxd
+++ b/tacs/TACS.pxd
@@ -253,6 +253,7 @@ cdef extern from "TACSElement.h":
     cdef cppclass TACSElement(TACSObject):
         int numNodes()
         int numVariables()
+        int getComponentNum()
         void setComponentNum(int)
         TACSConstitutive *getConstitutive()
 

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -886,6 +886,7 @@ cdef class Assembler:
             element = self.ptr.getElement(num, NULL, NULL, NULL, NULL)
             nnodes = element.numNodes()
             nvars = element.numVariables()
+            compID = element.getComponentNum()
 
             # Allocate the numpy array and retrieve the internal data
             Xpt = np.zeros(3*nnodes, dtype=dtype)
@@ -898,7 +899,7 @@ cdef class Assembler:
         else:
             raise ValueError('Element index out of range')
 
-        return _init_Element(element), Xpt, vars0, dvars, ddvars
+        return _init_Element(element), Xpt, vars0, dvars, ddvars, compID
 
     def getElementNodes(self, int num):
         '''Get the node numbers associated with the given element'''

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -261,8 +261,8 @@ cdef class Vec:
         cdef int bsize = 0
         cdef np.ndarray values
         bsize = self.ptr.getBlockSize()
-        length = bsize*var.shape[0]
-        values = np.zeros(length)
+        length = var.shape[0]
+        values = np.zeros(bsize*length)
         fail = self.ptr.getValues(length, <int*>var.data, <TacsScalar*>values.data)
         if fail:
             errmsg = 'Vec: Failed on get values. Incorrect indices'

--- a/tacs/functions.pyx
+++ b/tacs/functions.pyx
@@ -92,6 +92,9 @@ cdef class KSFailure(Function):
             self.ksptr.setKSFailureType(PNORM_FAILURE_CONTINUOUS)
         return
 
+    def setLoadFactor(self, TacsScalar loadFactor):
+        self.ksptr.setLoadFactor(loadFactor)
+
     def setParameter(self, double ksparam):
         self.ksptr.setParameter(ksparam)
 


### PR DESCRIPTION
## Purpose
This PR addresses three things:
- getValues member function bvec bug fix.
- compID added to return list for getElementData.
- setLoadFactor function added for KS failure function

Originally [developed by Nick](https://github.com/mdolab/tacs/commit/f2a1a2cc7e1ea231251360bfa64347307ff86711), but this PR splits into specific commits. 

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing
Test in pytacs repo can be run to test some of these additions. More tests should be added locally.

